### PR TITLE
Add Toggle minimap visibility

### DIFF
--- a/Modules/MinimapIcon.lua
+++ b/Modules/MinimapIcon.lua
@@ -28,6 +28,7 @@ local _LibDBIcon = LibStub("LibDBIcon-1.0");
 function DP_MinimapIcon:Initialize()
   _LibDBIcon:Register("DisenchanterPlus", _DP_MinimapIcon:CreateDataBrokerObject(), DisenchanterPlus.db.profile.minimap);
   DisenchanterPlus.minimapConfigIcon = _LibDBIcon
+  self:ToggleVisibility()
 end
 
 ---Create data object
@@ -109,4 +110,13 @@ end
 
 function DP_MinimapIcon:UpdateIcon(value)
   _DP_MinimapIcon.LDBDataObject.icon = value
+end
+
+function DP_MinimapIcon:ToggleVisibility()
+    local isHidden = DisenchanterPlus.db.profile.minimap.hide
+    if isHidden then
+        _LibDBIcon:Hide("DisenchanterPlus")
+    else
+        _LibDBIcon:Show("DisenchanterPlus")
+    end
 end

--- a/Modules/Settings/GeneralTab/Groups/GeneralGroup.lua
+++ b/Modules/Settings/GeneralTab/Groups/GeneralGroup.lua
@@ -24,6 +24,9 @@ end
 ---@param order? number
 ---@return table
 function DP_GeneralGroup:Config(order)
+  -- Import the Minimap module so we can call the toggle function
+  local DP_MinimapIcon = DP_ModuleLoader:ImportModule("DP_MinimapIcon")
+
   return {
     type = "group",
     order = order,
@@ -43,6 +46,24 @@ function DP_GeneralGroup:Config(order)
         set = function(info, value)
           DP_GeneralGroup:CheckStatus(value)
           DisenchanterPlus.db.char.general.disableAll = value
+        end,
+      },
+      -- NEW: Hide Minimap Icon Toggle
+      hideMinimap = {
+        type = "toggle",
+        order = 2, -- Appears below "Disable all"
+        name = "Hide Minimap Icon", -- You can wrap this in DP_i18n if you have translations
+        desc = "Hide the DisenchanterPlus button from the minimap.",
+        width = "full",
+        get = function()
+          return DisenchanterPlus.db.profile.minimap.hide
+        end,
+        set = function(info, value)
+          DisenchanterPlus.db.profile.minimap.hide = value
+          -- Call the visibility function to apply the change immediately
+          if DP_MinimapIcon and DP_MinimapIcon.ToggleVisibility then
+            DP_MinimapIcon:ToggleVisibility()
+          end
         end,
       },
     },

--- a/Modules/SlashCommands.lua
+++ b/Modules/SlashCommands.lua
@@ -19,15 +19,28 @@ function DP_SlashCommands.RegisterSlashCommands()
 end
 
 function DP_SlashCommands.HandleCommands(input)
+  -- Import the Minimap module
+  local DP_MinimapIcon = DP_ModuleLoader:ImportModule("DP_MinimapIcon")
   local command = string.lower(input) or "help"
+
   if command == "config" then
     DP_SlashCommands:OpenSettingsWindow()
   elseif command == "main" then
     DP_SlashCommands:OpenWelcomeWindow()
+  elseif command == "minimap" then
+    -- Toggle the boolean in your DB
+    DisenchanterPlus.db.profile.minimap.hide = not DisenchanterPlus.db.profile.minimap.hide
+    -- Call the visibility function we created in the first step
+    if DP_MinimapIcon and DP_MinimapIcon.ToggleVisibility then
+        DP_MinimapIcon:ToggleVisibility()
+        local status = DisenchanterPlus.db.profile.minimap.hide and "Hidden" or "Shown"
+        DisenchanterPlus:Print("Minimap icon is now: " .. status)
+    end
   else
     DisenchanterPlus:Print(format("|cffe1e1f1Disenchanter|r |cfff141bfPlus|r : %s", DisenchanterPlus:DP_i18n("Available commands")))
     DisenchanterPlus:Print(format("/dplus |cffc1c1c1config|r - %s", DisenchanterPlus:DP_i18n("Open settings window")))
     DisenchanterPlus:Print(format("/dplus |cffc1c1c1main|r - %s", DisenchanterPlus:DP_i18n("Open main window")))
+    DisenchanterPlus:Print(format("/dplus |cffc1c1c1minimap|r - %s", "Toggle minimap icon visibility"))
   end
 end
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ The addon can be managed using the following slash commands:
 
 - `/dplus`: Display help information.
 - `/dplus config`: Opens configuration window.
+- `/dplus minimap`: Toggle minimap icon visibility.
 
 ## Compatibility
 
-- **Classic WoW** (Season of Discovery, Classic Hardcore)
+- **Classic WoW** (Season of Discovery, Classic Hardcore, Classic Anniversary)
 - **Classic Cataclysm**
 
 ## Installation
@@ -32,6 +33,7 @@ The addon can be managed using the following slash commands:
 2. **Extract** to your WoW `Interface/AddOns` directory:
    - For **Classic Cataclysm**: `World of Warcraft/_classic_/Interface/AddOns`
    - For **Classic WoW** (Season of Discovery, Classic Hardcore): `World of Warcraft/_classic_era_/Interface/AddOns`
+   - For **Classic WoW Anniversary** : `World of Warcraft/_anniversary_/Interface/AddOns`
 3. **Restart WoW** or **Reload** to enable the addon in the AddOns menu.
 
 ## Feedback


### PR DESCRIPTION
I use the addon while multiboxing but I didn't want the icon on my minimap on the alts just needing the tooltip info.
Adds a slash command and an option on the general tab.